### PR TITLE
lint the molo core package templates

### DIFF
--- a/molo/core/scripts/template_lint.py
+++ b/molo/core/scripts/template_lint.py
@@ -28,7 +28,7 @@ def run():
 
     errors = [lint_template_file(filename) for filename in html_templates]
     if any(errors):
-        log_error("\n".join([error for error in errors if error]))
+        log_error(*[error for error in errors if error])
         exit_code = 1
 
     exit(exit_code)

--- a/molo/core/scripts/tests/test_utils.py
+++ b/molo/core/scripts/tests/test_utils.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from molo.core.scripts.utils import lint_template
+
+
+class TestTemplateList(TestCase):
+    def test_lint_template_file_pass(self):
+        self.assertEqual(
+            lint_template(
+                """{% load i18n %}
+                {% trans "translate me" %}
+                """
+            ),
+            []
+        )
+
+    def test_lint_template_file_failure(self):
+        self.assertEqual(
+            lint_template(
+                """{% load i18n %}
+                <p>translate me</p>
+                """
+            ),
+            ['Can remove i18n without error']
+        )
+
+    def test_lint_template_file_syntax_error(self):
+        self.assertEqual(
+            lint_template(
+                """{% oad i18n %}
+                <p>come words</p>
+                """
+            ),
+            [("TemplateSyntaxError while parsing template\n"
+              "\tInvalid block tag on line 1: 'oad'. Did you forget to "
+              "register or load this tag?")]
+        )

--- a/molo/core/scripts/utils.py
+++ b/molo/core/scripts/utils.py
@@ -14,7 +14,8 @@ def lint_template(template_string):
     try:
         Template(template_string)
     except TemplateSyntaxError as e:
-        errors.append('TemplateSyntaxError while parsing template\n\t{}'.format(str(e)))
+        errors.append(
+            'TemplateSyntaxError while parsing template\n\t{}'.format(str(e)))
 
     lines = template_string.split("\n")
 

--- a/molo/core/scripts/utils.py
+++ b/molo/core/scripts/utils.py
@@ -1,0 +1,53 @@
+from django.conf import settings
+from django.template import Template, TemplateSyntaxError
+
+
+def lint_template(template_string):
+    '''
+    Takes Django template file path
+    Returns array of error strings
+    '''
+    items_loaded = []
+    errors = []
+
+    # Ensure that the template renders
+    try:
+        Template(template_string)
+    except TemplateSyntaxError as e:
+        errors.append('TemplateSyntaxError while parsing template\n\t{}'.format(str(e)))
+
+    lines = template_string.split("\n")
+
+    for line in lines:
+        if "{% load " in line:
+            items_loaded += [
+                item for item in line.split(' ') if item not in [
+                    '{%', 'load', '', '%}']]
+
+    if len(items_loaded) != len(set(items_loaded)):
+        errors.append('Duplicate template tags loaded')
+
+    for load in items_loaded:
+        try:
+            padded_load = ' {0} '.format(load)
+            new_template_file = template_string.replace(padded_load, '')
+            Template(new_template_file)
+            errors.append('Can remove {0} without error'.format(load))
+        except TemplateSyntaxError:
+            pass
+
+    return errors
+
+
+def lint_template_file(filename):
+    printable_filename = filename.replace(settings.PROJECT_ROOT, '')
+    template_string = open(filename).read()
+    errors = lint_template(template_string)
+
+    if errors:
+        error_string = "ERROR: {}\n".format(printable_filename)
+        for error in errors:
+            error_string += '  {}\n'.format(error)
+
+        return error_string
+    return None

--- a/molo/core/tests/test_templates.py
+++ b/molo/core/tests/test_templates.py
@@ -9,9 +9,11 @@ from django.test import TestCase
 from django.conf import settings
 from molo.core.scripts.utils import lint_template_file
 
+
 class TestMoloCoreTemplates(TestCase):
     def test_lint_profile_templates(self):
-        app_template_dir = join(dirname(settings.PROJECT_ROOT), "molo", "core", "templates")
+        app_template_dir = join(
+            dirname(settings.PROJECT_ROOT), "molo", "core", "templates")
 
         html_templates = []
         template_directories = [
@@ -23,5 +25,5 @@ class TestMoloCoreTemplates(TestCase):
 
         errors = [lint_template_file(filename) for filename in html_templates]
         if any(errors):
-            print("\n".join([error for error in errors if error]), file=stderr)
+            print("\n".join([error for error in errors if error]), stderr)
         self.assertFalse(any(errors))

--- a/molo/core/tests/test_templates.py
+++ b/molo/core/tests/test_templates.py
@@ -1,0 +1,27 @@
+from sys import stderr
+
+from os import walk
+from os.path import join, dirname
+
+from glob import glob
+
+from django.test import TestCase
+from django.conf import settings
+from molo.core.scripts.utils import lint_template_file
+
+class TestMoloCoreTemplates(TestCase):
+    def test_lint_profile_templates(self):
+        app_template_dir = join(dirname(settings.PROJECT_ROOT), "molo", "core", "templates")
+
+        html_templates = []
+        template_directories = [
+            walk_result[0] for walk_result in
+            walk(app_template_dir)]
+
+        for directory in template_directories:
+            html_templates += glob(join(directory, '*.html'))
+
+        errors = [lint_template_file(filename) for filename in html_templates]
+        if any(errors):
+            print("\n".join([error for error in errors if error]), file=stderr)
+        self.assertFalse(any(errors))

--- a/molo/core/tests/test_templates.py
+++ b/molo/core/tests/test_templates.py
@@ -1,5 +1,3 @@
-from sys import stderr
-
 from os import walk
 from os.path import join, dirname
 
@@ -8,6 +6,7 @@ from glob import glob
 from django.test import TestCase
 from django.conf import settings
 from molo.core.scripts.utils import lint_template_file
+from molo.core.scripts.template_lint import log_error
 
 
 class TestMoloCoreTemplates(TestCase):
@@ -25,5 +24,5 @@ class TestMoloCoreTemplates(TestCase):
 
         errors = [lint_template_file(filename) for filename in html_templates]
         if any(errors):
-            print("\n".join([error for error in errors if error]), stderr)
+            log_error(*[error for error in errors if error])
         self.assertFalse(any(errors))

--- a/molo/profiles/tests/test_templates.py
+++ b/molo/profiles/tests/test_templates.py
@@ -1,5 +1,3 @@
-from sys import stderr
-
 from os import walk
 from os.path import join, dirname
 
@@ -8,6 +6,7 @@ from glob import glob
 from django.test import TestCase
 from django.conf import settings
 from molo.core.scripts.utils import lint_template_file
+from molo.core.scripts.template_lint import log_error
 
 
 class TestMoloProfileTemplates(TestCase):
@@ -25,5 +24,5 @@ class TestMoloProfileTemplates(TestCase):
 
         errors = [lint_template_file(filename) for filename in html_templates]
         if any(errors):
-            print("\n".join([error for error in errors if error]), stderr)
+            log_error(*[error for error in errors if error])
         self.assertFalse(any(errors))

--- a/molo/profiles/tests/test_templates.py
+++ b/molo/profiles/tests/test_templates.py
@@ -1,0 +1,27 @@
+from sys import stderr
+
+from os import walk
+from os.path import join, dirname
+
+from glob import glob
+
+from django.test import TestCase
+from django.conf import settings
+from molo.core.scripts.utils import lint_template_file
+
+class TestMoloProfileTemplates(TestCase):
+    def test_lint_profile_templates(self):
+        app_template_dir = join(dirname(settings.PROJECT_ROOT), "molo", "profiles", "templates")
+
+        html_templates = []
+        template_directories = [
+            walk_result[0] for walk_result in
+            walk(app_template_dir)]
+
+        for directory in template_directories:
+            html_templates += glob(join(directory, '*.html'))
+
+        errors = [lint_template_file(filename) for filename in html_templates]
+        if any(errors):
+            print("\n".join([error for error in errors if error]), file=stderr)
+        self.assertFalse(any(errors))

--- a/molo/profiles/tests/test_templates.py
+++ b/molo/profiles/tests/test_templates.py
@@ -9,9 +9,11 @@ from django.test import TestCase
 from django.conf import settings
 from molo.core.scripts.utils import lint_template_file
 
+
 class TestMoloProfileTemplates(TestCase):
     def test_lint_profile_templates(self):
-        app_template_dir = join(dirname(settings.PROJECT_ROOT), "molo", "profiles", "templates")
+        app_template_dir = join(
+            dirname(settings.PROJECT_ROOT), "molo", "profiles", "templates")
 
         html_templates = []
         template_directories = [
@@ -23,5 +25,5 @@ class TestMoloProfileTemplates(TestCase):
 
         errors = [lint_template_file(filename) for filename in html_templates]
         if any(errors):
-            print("\n".join([error for error in errors if error]), file=stderr)
+            print("\n".join([error for error in errors if error]), stderr)
         self.assertFalse(any(errors))


### PR DESCRIPTION
This PR is intended to refactor and reuse the template linting script that the great @alexmuller wrote for our django web apps and use them on the molo app templates as well. This is done by doing the following:
- refactoring the script code into reusable functions
- writing tests for the template linter functions
- adding the use of that script to a single test which runs as part of the standard test suite for `molo.core` and `molo.profiles`