### PR TITLE
Upgrade to wagatil 2.2

### DIFF
--- a/molo/core/templates/wagtailadmin/pages/edit.html
+++ b/molo/core/templates/wagtailadmin/pages/edit.html
@@ -1,23 +1,24 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailadmin_tags %}
-{% load gravatar %}
 {% load i18n %}
+{% load l10n %}
 {% load core_tags %}
-{% block titletag %}{% blocktrans with title=page.title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
-{% block bodyclass %}page-editor model-{{ content_type.model }}{% endblock %}
+{% block titletag %}{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
+{% block bodyclass %}page-editor {% if page.live %}page-is-live{% endif %} model-{{ content_type.model }} {% if page.locked %}page-locked{% endif %}{% endblock %}
 
 {% block content %}
     {% page_permissions page as page_perms %}
-    <header class="merged tab-merged nice-padding">
+    <header class="merged tab-merged">
         {% explorer_breadcrumb page %}
 
         <div class="row row-flush">
-            <div class="left col9">
-                <h1 class="icon icon-doc-empty-inverse">{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
+            <div class="left col9 header-title">
+                <h1 class="icon icon-doc-empty-inverse">
+                {% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
             </div>
             <div class="right col3">
                 {% trans "Status" %}
-                {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
+                {% include "wagtailadmin/shared/page_status_tag.html" with page=page_for_status %}
 
                 {% include "wagtailadmin/pages/_privacy_switch.html" with page=page page_perms=page_perms only %}
                 {% include "wagtailadmin/pages/_lock_switch.html" %}
@@ -27,10 +28,12 @@
 
     <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
+
         <input type="hidden" name="next" value="{{ next }}">
         {{ edit_handler.render_form_content }}
+
         {% if is_revision %}
-            <input type="hidden" name="revision" value="{{ revision.id }}" />
+            <input type="hidden" name="revision" value="{{ revision.id|unlocalize }}" />
         {% endif %}
 
         <footer>
@@ -72,7 +75,7 @@
                     </div>
                 </li>
 
-                <li class="actions preview">
+                <li class="preview">
                     {% trans 'Preview' as preview_label %}
                     {% if preview_modes|length > 1 %}
                         <div class="dropdown dropup dropdown-button match-width">
@@ -98,13 +101,15 @@
                             {% if page.get_latest_revision.user %}
                                 {% blocktrans with modified_by=page.get_latest_revision.user.get_full_name|default:page.get_latest_revision.user.get_username %}by {{ modified_by }}{% endblocktrans %}
                                 {% if page.get_latest_revision.user.email %}
-                                    <span class="avatar small icon icon-user"><img src="{% gravatar_url page.get_latest_revision.user.email 25 %}" /></span>
+                                    <span class="avatar small"><img src="{% avatar_url page.get_latest_revision.user.email 25 %}" /></span>
                                 {% endif %}
                             {% endif %}
                             <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="underlined">{% trans 'Revisions' %}</a>
                         {% endif %}
                     </p>
                 </li>
+                {% block extra_footer_actions %}
+                {% endblock %}
             </ul>
         </footer>
     </form>
@@ -112,8 +117,26 @@
 {% endblock %}
 
 {% block extra_css %}
-  {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_css.html" %}
 {% endblock %}
 {% block extra_js %}
-  {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+
+    <script>
+        $(function() {
+            /* Make user confirm before leaving the editor if there are unsaved changes */
+            {% trans "This page has unsaved changes." as confirmation_message %}
+            enableDirtyFormCheck(
+                '#page-edit-form',
+                {
+                    confirmationMessage: '{{ confirmation_message|escapejs }}',
+                    {% if has_unsaved_changes %}
+                        alwaysDirty: true,
+                    {% endif %}
+                }
+            );
+        });
+    </script>
 {% endblock %}

--- a/molo/core/templates/wagtailadmin/pages/edit.html
+++ b/molo/core/templates/wagtailadmin/pages/edit.html
@@ -100,9 +100,7 @@
                             {% blocktrans with last_mod=page.get_latest_revision.created_at %}Last modified: {{ last_mod }}{% endblocktrans %}
                             {% if page.get_latest_revision.user %}
                                 {% blocktrans with modified_by=page.get_latest_revision.user.get_full_name|default:page.get_latest_revision.user.get_username %}by {{ modified_by }}{% endblocktrans %}
-                                {% if page.get_latest_revision.user.email %}
-                                    <span class="avatar small"><img src="{% avatar_url page.get_latest_revision.user.email 25 %}" /></span>
-                                {% endif %}
+                                <span class="avatar small"><img src="{% avatar_url page.get_latest_revision.user size=25 %}" /></span>
                             {% endif %}
                             <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="underlined">{% trans 'Revisions' %}</a>
                         {% endif %}
@@ -119,10 +117,22 @@
 {% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ edit_handler.form.media.css }}
 {% endblock %}
+
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+
+    {% comment %}
+        Additional js from widgets media. Allows for custom widgets in admin panel.
+    {% endcomment %}
+    {{ edit_handler.form.media.js }}
+
+    {% comment %}
+        Additional HTML code that edit handlers define through 'html_declarations'. (Technically this isn't Javascript, but it will generally be data that exists for Javascript to work with...)
+    {% endcomment %}
+    {{ edit_handler.html_declarations }}
 
     <script>
         $(function() {

--- a/molo/core/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/molo/core/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -19,7 +19,9 @@
     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
 </h2>
 
+{# BEGIN CUSTOM TEMPLATE LOGIC #}
 {% render_translations page %}
+{# END CUSTOM TEMPLATE LOGIC #}
 <ul class="actions">
     {% page_listing_buttons page page_perms %}
 </ul>

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     'ujson==1.35',
     'unicodecsv==0.14.1',
     'unicore.content',
-    'wagtail>=2.0,<2.1',
+    'wagtail>=2.1,<2.2',
     'wagtailmedia==0.2.0',
     'ImageHash==3.4',
     'boto==2.49.0',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     'ujson==1.35',
     'unicodecsv==0.14.1',
     'unicore.content',
-    'wagtail>=2.1,<2.2',
+    'wagtail>=2.2,<2.3',
     'wagtailmedia==0.2.0',
     'ImageHash==3.4',
     'boto==2.49.0',


### PR DESCRIPTION
Upgrade wagtail requirement to v2.2
In this version they removed the gravatar requirement so we need to remove references to that in the templates.
This showed that some of the templates were out of date so I updated them as well.