### PR TITLE
check if reaction question submission is made via ajax call

### DIFF
--- a/molo/core/templatetags/core_tags.py
+++ b/molo/core/templatetags/core_tags.py
@@ -647,6 +647,20 @@ def load_user_can_vote_on_reaction_question(context, question, article_pk):
 
 @register.simple_tag(takes_context=True)
 @prometheus_query_count
+def load_user_choice_reaction_question(context, question, article, choice):
+    request = context['request']
+    if question:
+        question = question.specific.get_main_language_page()
+        article = ArticlePage.objects.get(pk=article)
+        if hasattr(article, 'get_main_language_page'):
+            article = article.get_main_language_page()
+        return ReactionQuestionResponse.objects.filter(
+            article=article, choice=choice,
+            question=question, user=request.user).exists()
+
+
+@register.simple_tag(takes_context=True)
+@prometheus_query_count
 def load_reaction_question(context, article):
     locale = context.get('locale_code')
     request = context['request']

--- a/molo/core/tests/test_template_tags.py
+++ b/molo/core/tests/test_template_tags.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import pytest
 from mock import patch
+from django.contrib.auth.models import User
 from django.utils import timezone
 from django.test import TestCase, RequestFactory
 from molo.core.models import (
@@ -12,6 +13,7 @@ from molo.core.templatetags.core_tags import (
     get_parent, bannerpages, load_tags_for_article, get_recommended_articles,
     hero_article, render_translations, load_descendant_articles_for_section,
     load_child_articles_for_section, load_reaction_choice_submission_count,
+    load_user_choice_reaction_question
 )
 from molo.core.templatetags.forms_tags import forms_list
 
@@ -66,6 +68,35 @@ class TestModels(TestCase, MoloTestCaseMixin):
         }
         context = forms_list(context)
         self.assertEqual(len(context['forms']), 1)
+
+    def test_load_user_choice_reaction_question(self):
+        article = self.mk_articles(self.yourmind, 1)[0]
+        question = ReactionQuestion(title='q1')
+        ReactionQuestionIndexPage.objects.last().add_child(instance=question)
+        question.save_revision().publish()
+        choice = ReactionQuestionChoice(title='yes')
+        question.add_child(instance=choice)
+        choice.save_revision().publish()
+        choice2 = ReactionQuestionChoice(title='no')
+        question.add_child(instance=choice2)
+        choice2.save_revision().publish()
+        user = User.objects.create_superuser(
+            username='testuser', password='password', email='test@email.com')
+        ReactionQuestionResponse.objects.create(
+            choice=choice, article=article, question=question,
+            user=user)
+        request = self.factory.get('/')
+        request.user = user
+        self.assertTrue(load_user_choice_reaction_question(
+            {'request': request},
+            question=question,
+            choice=choice,
+            article=article))
+        self.assertFalse(load_user_choice_reaction_question(
+            {'request': request},
+            question=question,
+            choice=choice2,
+            article=article))
 
     def test_reaction_question_submission_count(self):
         article = self.mk_articles(self.yourmind, 1)[0]

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -272,7 +272,8 @@ class ReactionQuestionChoiceView(FormView):
                 created.save()
 
         else:
-            if 'ajax' in self.request.POST and self.request.POST['ajax'] == 'True':
+            if 'ajax' in self.request.POST and \
+                    self.request.POST['ajax'] == 'True':
                 response = ReactionQuestionResponse.objects.filter(
                     article=article.pk, question=question_id,
                     user=self.request.user).last()

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -272,9 +272,16 @@ class ReactionQuestionChoiceView(FormView):
                 created.save()
 
         else:
-            messages.error(
-                self.request,
-                "You have already given feedback on this article.")
+            if 'ajax' in self.request.POST and self.request.POST['ajax'] == 'True':
+                response = ReactionQuestionResponse.objects.filter(
+                    article=article.pk, question=question_id,
+                    user=self.request.user).last()
+                response.choice = choice
+                response.save()
+            else:
+                messages.error(
+                    self.request,
+                    "You have already given feedback on this article.")
         return super(ReactionQuestionChoiceView, self).form_valid(
             form, *args, **kwargs)
 


### PR DESCRIPTION
On certain projects we would like to be able to submit a reaction question response via an ajax call. When a user submits via an ajax calls the rules are a bit different. The following changes are necessary to make sure that when submitting via ajax call the user is allowed to change their vote and is not shown a message of you have already voted